### PR TITLE
Lvs rules

### DIFF
--- a/steps/mentor-calibre-lvs/README.md
+++ b/steps/mentor-calibre-lvs/README.md
@@ -1,0 +1,6 @@
+This node: 
+* Accepts an additional file of SVRF statements as an input (rules.svrf). The most common use case here would be to add LVS BOX commands to blackbox hard macros present in the design
+
+* Globs for all *.spi files in input directory. These files need to be included for all hard macros in design.
+
+* Outputs spice file, for use in downstream hierarchical LVS.

--- a/steps/mentor-calibre-lvs/configure.yml
+++ b/steps/mentor-calibre-lvs/configure.yml
@@ -12,12 +12,14 @@ name: mentor-calibre-lvs
 #-------------------------------------------------------------------------
 
 inputs:
+  - rules.svrf
   - design_merged.gds
   - design.lvs.v
   - adk
 
 outputs:
   - lvs.report
+  - design.spi
 
 #-------------------------------------------------------------------------
 # Commands
@@ -25,9 +27,11 @@ outputs:
 
 commands:
   - envsubst < lvs.runset.template > lvs.runset
+  - if [ ! -f inputs/*.svrf ]; then touch inputs/rules.svrf; fi
   - calibre -gui -lvs -batch -runset lvs.runset
   - mkdir -p outputs && cd outputs
   - ln -sf ../lvs.report
+  - ln -sf ../_design.lvs.v.sp design.spi
 
 #-------------------------------------------------------------------------
 # Parameters

--- a/steps/mentor-calibre-lvs/configure.yml
+++ b/steps/mentor-calibre-lvs/configure.yml
@@ -19,7 +19,7 @@ inputs:
 
 outputs:
   - lvs.report
-  - design.spi
+  - design.schematic.spi
 
 #-------------------------------------------------------------------------
 # Commands
@@ -31,7 +31,7 @@ commands:
   - calibre -gui -lvs -batch -runset lvs.runset
   - mkdir -p outputs && cd outputs
   - ln -sf ../lvs.report
-  - ln -sf ../_design.lvs.v.sp design.spi
+  - ln -sf ../_design.lvs.v.sp design.schematic.spi
 
 #-------------------------------------------------------------------------
 # Parameters

--- a/steps/mentor-calibre-lvs/lvs.runset.template
+++ b/steps/mentor-calibre-lvs/lvs.runset.template
@@ -17,5 +17,5 @@
 *cmnTranscriptEchoToFile: 1
 *cmnRunMT: 1
 *cmnRunHyper: 1
-*cmnV2LVS_SPICEIncFiles: inputs/adk/stdcells.cdl
+*cmnV2LVS_SPICEIncFiles: inputs/adk/stdcells.cdl inputs/*.spi
 *cmnV2LVS_UseRangeMode: 1

--- a/steps/mentor-calibre-lvs/lvs.runset.template
+++ b/steps/mentor-calibre-lvs/lvs.runset.template
@@ -1,4 +1,6 @@
 *lvsRulesFile: inputs/adk/calibre-lvs.rule
+*lvsIncludeFiles: inputs/*.svrf
+*lvsIncludeCmdsType: SVRF
 *lvsRunDir: ./
 *lvsLayoutPaths: inputs/design_merged.gds
 *lvsLayoutPrimary: ${design_name}


### PR DESCRIPTION
This PR enhances the default LVS node so that is can work better with hierarchical designs.

Main additions:
- accepts an additional file of SVRF statements as inputs. The most common use case here would be to add `LVS BOX` commands to blackbox hard macros present in the design
- Globs for *.spi files in input directory. These files need to be included for all hard macros in design.
- Outputs spice file, for use in hierarchical LVS.