### PR TITLE
Make genlibdb glob for input *db files as link libs

### DIFF
--- a/steps/synopsys-ptpx-genlibdb/designer_interface.tcl
+++ b/steps/synopsys-ptpx-genlibdb/designer_interface.tcl
@@ -17,6 +17,7 @@
 
 set ptpx_additional_search_path   inputs/adk
 set ptpx_target_libraries         inputs/adk/stdcells.db
+set ptpx_extra_link_libraries     [glob -nocomplain inputs/*.db]
 
 #-------------------------------------------------------------------------
 # Interface to the build system

--- a/steps/synopsys-ptpx-genlibdb/scripts/read_design.tcl
+++ b/steps/synopsys-ptpx-genlibdb/scripts/read_design.tcl
@@ -14,7 +14,7 @@ source -echo -verbose designer_interface.tcl
 
 set_app_var search_path      ". $ptpx_additional_search_path $search_path"
 set_app_var target_library   $ptpx_target_libraries
-set_app_var link_library     "* $ptpx_target_libraries"
+set_app_var link_library     "* $ptpx_target_libraries $ptpx_extra_link_libraries"
 
 #-------------------------------------------------------------------------
 # Read design


### PR DESCRIPTION
This PR enables the default genlibdb step to work with hierarchical designs by adding all *.db files in the inputs directory as link_libs when extracting timing models.