### PR TITLE
Make lvs look for all *.cdl files in adk

### DIFF
--- a/steps/mentor-calibre-lvs/lvs.runset.template
+++ b/steps/mentor-calibre-lvs/lvs.runset.template
@@ -19,5 +19,5 @@
 *cmnTranscriptEchoToFile: 1
 *cmnRunMT: 1
 *cmnRunHyper: 1
-*cmnV2LVS_SPICEIncFiles: inputs/adk/*.cdl inputs/*.spi
+*cmnV2LVS_SPICEIncFiles: inputs/adk/*.cdl inputs/*.spi inputs/*.sp
 *cmnV2LVS_UseRangeMode: 1

--- a/steps/mentor-calibre-lvs/lvs.runset.template
+++ b/steps/mentor-calibre-lvs/lvs.runset.template
@@ -19,5 +19,5 @@
 *cmnTranscriptEchoToFile: 1
 *cmnRunMT: 1
 *cmnRunHyper: 1
-*cmnV2LVS_SPICEIncFiles: inputs/adk/stdcells.cdl inputs/*.spi
+*cmnV2LVS_SPICEIncFiles: inputs/adk/*.cdl inputs/*.spi
 *cmnV2LVS_UseRangeMode: 1


### PR DESCRIPTION
Make the LVS node accept all .cdl files in the adk. This will be necessary for fullchip LVS and LVS with power domains for Garnet because spice files for power management cells, pads, etc. are required.