### PR TITLE
[synopsys-ptpx-genlibdb] - Update script to check if spef files exist

### DIFF
--- a/steps/cadence-innovus-init/scripts/pin-assignments.tcl
+++ b/steps/cadence-innovus-init/scripts/pin-assignments.tcl
@@ -39,7 +39,5 @@ if { $clock_ports != 0 } {
 
 set ports_layer M4
 
-editPin -layer $ports_layer -pin $pins_left_half  -side LEFT  -spreadType SIDE
-editPin -layer $ports_layer -pin $pins_right_half -side RIGHT -spreadType SIDE
-
-
+#editPin -layer $ports_layer -pin $pins_left_half  -side LEFT  -spreadType SIDE
+#editPin -layer $ports_layer -pin $pins_right_half -side RIGHT -spreadType SIDE

--- a/steps/cadence-innovus-init/scripts/pin-assignments.tcl
+++ b/steps/cadence-innovus-init/scripts/pin-assignments.tcl
@@ -39,5 +39,5 @@ if { $clock_ports != 0 } {
 
 set ports_layer M4
 
-#editPin -layer $ports_layer -pin $pins_left_half  -side LEFT  -spreadType SIDE
-#editPin -layer $ports_layer -pin $pins_right_half -side RIGHT -spreadType SIDE
+editPin -layer $ports_layer -pin $pins_left_half  -side LEFT  -spreadType SIDE
+editPin -layer $ports_layer -pin $pins_right_half -side RIGHT -spreadType SIDE

--- a/steps/synopsys-dc-synthesis/run.sh
+++ b/steps/synopsys-dc-synthesis/run.sh
@@ -75,13 +75,20 @@ fi
 
 $dc_exec $opt_topographical -f dc.tcl -output_log_file logs/dc.log || exit 1
 
+# Compress the spef file
+
+cd results
+gzip *.mapped.spef
+cd ..
+
 # Set up the outputs
 
 mkdir -p outputs && cd outputs
 
-ln -sf ../results/*.mapped.v design.v
-ln -sf ../results/*.mapped.sdc design.sdc
-ln -sf ../reports/*.namemap design.namemap
+ln -sf ../results/*.mapped.v       design.v
+ln -sf ../results/*.mapped.sdc     design.sdc
+ln -sf ../results/*.mapped.spef.gz design.spef.gz
+ln -sf ../reports/*.namemap        design.namemap
 
 cd ..
 
@@ -105,5 +112,3 @@ grep --color "unresolved references." logs/dc.log || true
 #
 
 grep --color "ELAB-405" logs/dc.log || true
-
-

--- a/steps/synopsys-ptpx-genlibdb/START.tcl
+++ b/steps/synopsys-ptpx-genlibdb/START.tcl
@@ -26,9 +26,9 @@
 # Execute
 #-------------------------------------------------------------------------
 
-# Order is a comma-separated string containing scripts to run  
+# Order is a comma-separated string containing scripts to run
 
-set order [split $::env(order) ","]                            
+set order [split $::env(order) ","]
 
 # Run the scripts in order (inputs take priority)
 
@@ -49,4 +49,3 @@ foreach tcl $order {
 }
 
 exit
-

--- a/steps/synopsys-ptpx-genlibdb/configure.yml
+++ b/steps/synopsys-ptpx-genlibdb/configure.yml
@@ -50,6 +50,7 @@ preconditions:
   - assert File( 'inputs/adk' )              # must exist
   - assert File( 'inputs/design.vcs.v' )     # must exist
   - assert File( 'inputs/design.pt.sdc' )    # must exist
+# - assert File( 'inputs/design.spef.gz' )   # spef is optional
 
 postconditions:
 

--- a/steps/synopsys-ptpx-genlibdb/configure.yml
+++ b/steps/synopsys-ptpx-genlibdb/configure.yml
@@ -49,7 +49,6 @@ preconditions:
   - assert Tool( 'pt_shell' )                # tool check
   - assert File( 'inputs/adk' )              # must exist
   - assert File( 'inputs/design.vcs.v' )     # must exist
-  - assert File( 'inputs/design.spef.gz' )   # must exist
   - assert File( 'inputs/design.pt.sdc' )    # must exist
 
 postconditions:
@@ -62,5 +61,3 @@ postconditions:
   - assert 'error' not in File( 'logs/pt.log' )
   - assert 'Unresolved references' not in File( 'logs/pt.log' )
   - assert 'Unable to resolve' not in File( 'logs/pt.log' )
-
-

--- a/steps/synopsys-ptpx-genlibdb/scripts/read_design.tcl
+++ b/steps/synopsys-ptpx-genlibdb/scripts/read_design.tcl
@@ -28,6 +28,18 @@ current_design $ptpx_design_name
 link_design
 
 # Read in the SDC and parasitics
+# Try to read the sdc constraints files
+if {[ file exists $ptpx_sdc ]} {
+    puts "\n  > Info: Sourcing $ptpx_sdc\"\n"
+    read_sdc -echo $ptpx_sdc
+}  else {
+    puts "\n  > Warn: No sdc constraint file found\"\n"
+}
 
-read_sdc -echo $ptpx_sdc
-read_parasitics -format spef $ptpx_spef
+# Try to read the sped parasitic files
+if {[ file exists $ptpx_spef ]} {
+    puts "\n  > Info: Sourcing $ptpx_sdc\"\n"
+    read_parasitics -format spef $ptpx_spef
+}  else {
+    puts "\n  > Warn: No spef parasitic file found\"\n"
+}

--- a/steps/synopsys-ptpx-genlibdb/scripts/read_design.tcl
+++ b/steps/synopsys-ptpx-genlibdb/scripts/read_design.tcl
@@ -29,6 +29,7 @@ link_design
 
 # Read in the SDC and parasitics
 # Try to read the sdc constraints files
+
 if {[ file exists $ptpx_sdc ]} {
     puts "\n  > Info: Sourcing $ptpx_sdc\"\n"
     read_sdc -echo $ptpx_sdc
@@ -36,7 +37,8 @@ if {[ file exists $ptpx_sdc ]} {
     puts "\n  > Warn: No sdc constraint file found\"\n"
 }
 
-# Try to read the sped parasitic files
+# Try to read the spef parasitic files
+
 if {[ file exists $ptpx_spef ]} {
     puts "\n  > Info: Sourcing $ptpx_sdc\"\n"
     read_parasitics -format spef $ptpx_spef


### PR DESCRIPTION
This step can now be used after synthesis to generate lib files
The spef files are no more mandatory as inputs of the step