### PR TITLE
Copy correct file to output folder

### DIFF
--- a/steps/mentor-calibre-lvs/configure.yml
+++ b/steps/mentor-calibre-lvs/configure.yml
@@ -28,7 +28,7 @@ outputs:
 commands:
   - envsubst < lvs.runset.template > lvs.runset
   - if [ ! -f inputs/*.svrf ]; then touch inputs/rules.svrf; fi
-  - cat inputs/*.lvs.v > inputs/merged.v
+  - cat inputs/*.lvs.v > merged.v
   - calibre -gui -lvs -batch -runset lvs.runset
   - mkdir -p outputs && cd outputs
   - ln -sf ../lvs.report

--- a/steps/mentor-calibre-lvs/configure.yml
+++ b/steps/mentor-calibre-lvs/configure.yml
@@ -32,7 +32,7 @@ commands:
   - calibre -gui -lvs -batch -runset lvs.runset
   - mkdir -p outputs && cd outputs
   - ln -sf ../lvs.report
-  - ln -sf ../_design.lvs.v.sp design.schematic.spi
+  - ln -sf ../_merged.v.sp design.schematic.spi
 
 #-------------------------------------------------------------------------
 # Parameters

--- a/steps/mentor-calibre-lvs/configure.yml
+++ b/steps/mentor-calibre-lvs/configure.yml
@@ -28,6 +28,7 @@ outputs:
 commands:
   - envsubst < lvs.runset.template > lvs.runset
   - if [ ! -f inputs/*.svrf ]; then touch inputs/rules.svrf; fi
+  - cat inputs/*.lvs.v > inputs/merged.v
   - calibre -gui -lvs -batch -runset lvs.runset
   - mkdir -p outputs && cd outputs
   - ln -sf ../lvs.report

--- a/steps/mentor-calibre-lvs/lvs.runset.template
+++ b/steps/mentor-calibre-lvs/lvs.runset.template
@@ -4,7 +4,7 @@
 *lvsRunDir: ./
 *lvsLayoutPaths: inputs/design_merged.gds
 *lvsLayoutPrimary: ${design_name}
-*lvsSourcePath: inputs/merged.v
+*lvsSourcePath: merged.v
 *lvsSourceSystem: VERILOG
 *lvsSourcePrimary: ${design_name}
 *lvsSpiceFile: lvs.extracted.sp

--- a/steps/mentor-calibre-lvs/lvs.runset.template
+++ b/steps/mentor-calibre-lvs/lvs.runset.template
@@ -4,10 +4,11 @@
 *lvsRunDir: ./
 *lvsLayoutPaths: inputs/design_merged.gds
 *lvsLayoutPrimary: ${design_name}
-*lvsSourcePath: inputs/design.lvs.v
+*lvsSourcePath: inputs/merged.v
 *lvsSourceSystem: VERILOG
 *lvsSourcePrimary: ${design_name}
 *lvsSpiceFile: lvs.extracted.sp
+*lvsRecognizeGates: NONE
 *lvsERCDatabase: lvs.erc.results
 *lvsERCSummaryFile: lvs.erc.summary
 *lvsReportFile: lvs.report


### PR DESCRIPTION
I restored previous branch because there was a bug.
As we changed the file name to `merged`, v2lvs will dump `_merged.v.sp` spice file.
Fixed script to copy correct spice file to output folder.