### PR TITLE
Revert "skip filler in verifyConnectivity"

### DIFF
--- a/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/verify-connectivity.tcl
+++ b/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/verify-connectivity.tcl
@@ -1,1 +1,0 @@
-verifyConnectivity -noAntenna -noFill

--- a/steps/cadence-innovus-flowsetup/setup.tcl
+++ b/steps/cadence-innovus-flowsetup/setup.tcl
@@ -378,10 +378,6 @@ set vars(signoff,stream_out,replace_tcl)      $vars(custom_scripts_dir)/stream-o
 
 set vars(signoff,summary_report,replace_tcl)  $vars(custom_scripts_dir)/summary-report.tcl
 
-# Custom verifyConnectivity - skip fill
-
-set vars(signoff,verify_connectivity,replace_tcl)      $vars(custom_scripts_dir)/verify-connectivity.tcl
-
 #-------------------------------------------------------------------------
 # Misc
 #-------------------------------------------------------------------------


### PR DESCRIPTION
Reverts cornell-brg/mflowgen#32

Still runs out of memory on large designs with DCAP. We will just skip verifyConnectivity in large designs where it runs out of memory.