### PR TITLE
[mflowgen] stash only outputs

### DIFF
--- a/mflowgen/backends/make_backend.py
+++ b/mflowgen/backends/make_backend.py
@@ -242,6 +242,26 @@ class MakeBackend:
     cd_idx    = tokens.index( 'cd' )
     build_dir = tokens[ cd_idx + 1 ]
 
+    #.....................................................................
+    # Built-in toggle for enabling/disabling this rule
+    #.....................................................................
+    # This is a hack -- Add a knob for Makefiles to enable/disable this
+    # rule. The goal and primary use case in mind here is to allow users
+    # to copy in pre-built steps and have the build system think its
+    # dependencies have all already been satisfied. We cannot just "touch"
+    # files from earlier steps to make it seem like they are done, since
+    # downstream steps may need those files. The only way we see to make
+    # pre-built steps always look "done" without impacting earlier steps
+    # is to break the dependency. Specifically, if the "directory" and
+    # "collect-inputs" substeps are removed, then a pre-built step will
+    # always look "done". So we add a knob here that checks if the step
+    # build directory has a ".prebuilt" file and if so, ignores this rule.
+    dst_dir = build_dir
+    s.w.write( 'ifeq ("$(wildcard {}/.prebuilt)","")'.format( dst_dir ) )
+    s.w.newline()
+    s.w.newline()
+    #.....................................................................
+
     rule = build_dir + '-commands-rule'
     rule = rule.replace( '-', '_' )
 
@@ -269,6 +289,15 @@ class MakeBackend:
       deps         = all_deps,
       touch_target = not phony,
     )
+
+    #.....................................................................
+    # Built-in toggle for enabling/disabling this rule
+    #.....................................................................
+    # Clean up from the above
+    s.w.write( 'endif' )
+    s.w.newline()
+    s.w.newline()
+    #.....................................................................
 
     return targets
 

--- a/mflowgen/cli.py
+++ b/mflowgen/cli.py
@@ -19,6 +19,8 @@
 #  -m --msg      string --  Push message for stash push
 #     --hash     string --  Hash for stash pull, stash pop, stash drop
 #
+#     --only-outputs    --  Stash push will only contain the outputs
+#
 # mflowgen mock (Mock-related options)
 #
 #  -p --path     string --  Path to step directory
@@ -75,6 +77,7 @@ def parse_cmdline():
   p.add_argument( "-s", "--step", type=int                        )
   p.add_argument( "-m", "--msg"                                   )
   p.add_argument(       "--hash"                                  )
+  p.add_argument(       "--only-outputs", action="store_true"     )
   opts = p.parse_args()
   if opts.help and not opts.args: p.error() # print help only if not stash
   return opts
@@ -105,12 +108,13 @@ def main():
   if opts.args and opts.args[0] == 'stash':
     shandler = StashHandler()
     shandler.launch(
-      args  = opts.args[1:],
-      help_ = opts.help,
-      path  = opts.path,
-      step  = opts.step,
-      msg   = opts.msg,
-      hash_ = opts.hash,
+      args   = opts.args[1:],
+      help_  = opts.help,
+      path   = opts.path,
+      step   = opts.step,
+      msg    = opts.msg,
+      hash_  = opts.hash,
+      only_o = opts.only_outputs,
     )
     return
 

--- a/mflowgen/stash/stash_handler.py
+++ b/mflowgen/stash/stash_handler.py
@@ -197,7 +197,7 @@ class StashHandler:
   # Dispatch function for commands
   #
 
-  def launch( s, args, help_, path, step, msg, hash_ ):
+  def launch( s, args, help_, path, step, msg, hash_, only_o ):
 
     if help_ and not args:
       s.launch_help()
@@ -222,7 +222,7 @@ class StashHandler:
     if   command == 'init' : s.launch_init( help_, path )
     elif command == 'link' : s.launch_link( help_, path )
     elif command == 'list' : s.launch_list( help_ )
-    elif command == 'push' : s.launch_push( help_, step, msg )
+    elif command == 'push' : s.launch_push( help_, step, msg, only_o )
     elif command == 'pull' : s.launch_pull( help_, hash_ )
     elif command == 'pop'  : s.launch_pop ( help_, hash_ )
     elif command == 'drop' : s.launch_drop( help_, hash_ )
@@ -376,10 +376,11 @@ class StashHandler:
   # Internally, this command does the following:
   #
   # - Copies the target step build directory to the stash
+  #     - if "only_o" is True, then only stash the outputs
   # - Updates the metadata YAML in the stash directory
   #
 
-  def launch_push( s, help_, step, msg ):
+  def launch_push( s, help_, step, msg, only_o ):
 
     try:
       author = os.environ[ 'USER' ]
@@ -391,7 +392,8 @@ class StashHandler:
     def print_help():
       print()
       print( bold( 'Usage:' ), 'mflowgen stash push',
-                                  '--step/-s <int> --message/-m "<str>"' )
+                                  '--step/-s <int> --message/-m "<str>"',
+                                  '[--only-outputs]'                     )
       print()
       print( bold( 'Example:' ), 'mflowgen stash push',
                                     '--step 5 -m "foo bar"'              )
@@ -401,7 +403,8 @@ class StashHandler:
       print( 'permissions) while following all symlinks. Then the'       )
       print( 'stashed copy is given a hash stamp and is marked as'       )
       print( 'authored by $USER (' + author + '). An optional message'   )
-      print( 'can also be attached to the push.'                         )
+      print( 'can also be attached to the push. If --only-outputs is'    )
+      print( 'given, then the stash will only contain outputs.'          )
       print()
 
     if help_ or not step or not msg:
@@ -442,12 +445,37 @@ class StashHandler:
 
     dst_dirname = '-'.join( [ datestamp, step_name, hashstamp ] )
 
+    # Helper function for '--only-outputs' to ignore copying other files
+
+    def f_ignore( path, files ):
+      # For nested subdirectories, ignore all files
+      if '/' in path:
+        if path.split('/')[1] == 'outputs':
+          return []     # ignore nothing in outputs
+        else:
+          return files  # ignore everything for any other directory
+      # At the top level, keep only outputs and a few other misc files
+      keep = [
+        'outputs',
+        'configure.yml',
+        'mflowgen-run.log',
+        '.time_start',
+        '.time_end',
+        '.stamp',
+        '.execstamp',
+        '.postconditions.stamp',
+      ]
+      ignore = [ _ for _ in files if _ not in keep ]
+      return ignore
+
     # Now copy src to dst
     #
-    # - symlinks                 = False # Follow all symlinks
-    # - ignore_dangling_symlinks = False # Stop with error if we cannot
-    #                                    #  follow a link to something
-    #                                    #  we need
+    # - symlinks                 = False  # Follow all symlinks
+    # - ignore_dangling_symlinks = False  # Stop with error if we cannot
+    #                                     #  follow a link to something
+    #                                     #  we need
+    # - ignore                   = (func) # Ignore all but the outputs if
+    #                                     #  the option "only_o" was given
     #
 
     remote_path = s.get_stash_path() + '/' + dst_dirname
@@ -456,6 +484,7 @@ class StashHandler:
       shutil.copytree( src      = push_target,
                        dst      = remote_path,
                        symlinks = False,
+                       ignore   = f_ignore if only_o else None,
                        ignore_dangling_symlinks = False )
     except shutil.Error:
       # According to online discussion, ignore_dangling_symlinks does not


### PR DESCRIPTION
Extra flag for mflowgen stash --only-outputs which only stashes the outputs.

Now you cannot re-run after stash pulling a step (and cannot look at any inputs or logs) but it still pins the outputs and feeds the graph nodes downstream.