### PR TITLE
Dc uniquify

### DIFF
--- a/steps/synopsys-dc-synthesis/configure.yml
+++ b/steps/synopsys-dc-synthesis/configure.yml
@@ -44,7 +44,7 @@ parameters:
   # Uniquify by prefixing every module in the design with the design name.
   # This is useful for hierarchical LVS when multiple blocks use modules
   # with the same name but different definitions.
-  uniquify_with_design_name: False
+  uniquify_with_design_name: True
 
 #-------------------------------------------------------------------------
 # Debug

--- a/steps/synopsys-dc-synthesis/configure.yml
+++ b/steps/synopsys-dc-synthesis/configure.yml
@@ -41,6 +41,10 @@ parameters:
   flatten_effort: 0
   topographical: True
   nthreads: 16  # multithreading available to the tool
+  # Uniquify by prefixing every module in the design with the design name.
+  # This is useful for hierarchical LVS when multiple blocks use modules
+  # with the same name but different definitions.
+  uniquify_with_design_name: False
 
 #-------------------------------------------------------------------------
 # Debug

--- a/steps/synopsys-dc-synthesis/dc.tcl
+++ b/steps/synopsys-dc-synthesis/dc.tcl
@@ -427,7 +427,7 @@ set_svf -off
 # This is useful for hierarchical LVS when multiple blocks use modules
 # with the same name but different definitions.
 
-if { $dc_uniquify_with_design_name == True }
+if { $dc_uniquify_with_design_name == True } {
   set uniquify_naming_style "${dc_design_name}_%s_%d"
   uniquify -force
 }

--- a/steps/synopsys-dc-synthesis/dc.tcl
+++ b/steps/synopsys-dc-synthesis/dc.tcl
@@ -423,6 +423,15 @@ if {[file exists "inputs/run.saif" ]} {
 
 set_svf -off
 
+# Uniquify by prefixing every module in the design with the design name.
+# This is useful for hierarchical LVS when multiple blocks use modules
+# with the same name but different definitions.
+
+if { $dc_uniquify_with_design_name == True }
+  set uniquify_naming_style "${dc_design_name}_%s_%d"
+  uniquify -force
+}
+
 # Use naming rules to preserve structs
 
 define_name_rules verilog -preserve_struct_ports

--- a/steps/synopsys-dc-synthesis/designer_interface.tcl
+++ b/steps/synopsys-dc-synthesis/designer_interface.tcl
@@ -17,11 +17,12 @@
 # Parameters
 #-------------------------------------------------------------------------
 
-set dc_design_name              $::env(design_name)
-set dc_saif_instance            $::env(saif_instance)
-set dc_clock_period             $::env(clock_period)
-set dc_flatten_effort           $::env(flatten_effort)
-set dc_topographical            $::env(topographical)
+set dc_design_name                $::env(design_name)
+set dc_saif_instance              $::env(saif_instance)
+set dc_clock_period               $::env(clock_period)
+set dc_flatten_effort             $::env(flatten_effort)
+set dc_topographical              $::env(topographical)
+set dc_uniquify_with_design_name  $::env(uniquify_with_design_name)
 
 #-------------------------------------------------------------------------
 # Inputs


### PR DESCRIPTION
Add parameter to prefix all modules with the design name to avoid name conflicts in hierarchical designs