### PR TITLE
update ptpx_extra_link_libraries 

### DIFF
--- a/steps/synopsys-ptpx-genlibdb/designer_interface.tcl
+++ b/steps/synopsys-ptpx-genlibdb/designer_interface.tcl
@@ -17,7 +17,7 @@
 
 set ptpx_additional_search_path   inputs/adk
 set ptpx_target_libraries         inputs/adk/stdcells.db
-set ptpx_extra_link_libraries     [glob -nocomplain inputs/*.db]
+set ptpx_extra_link_libraries     [glob -nocomplain inputs/*.db inputs/adk/*.db]
 
 #-------------------------------------------------------------------------
 # Interface to the build system


### PR DESCRIPTION
update ptpx_extra_link_libraries in genlibdb step to include inputs/adk path (In this case because of this missing path the power management dbs were not getting linked). 