### PR TITLE
Add all *db files in adk to ptpx_link_libs

### DIFF
--- a/steps/synopsys-ptpx-genlibdb/designer_interface.tcl
+++ b/steps/synopsys-ptpx-genlibdb/designer_interface.tcl
@@ -17,7 +17,10 @@
 
 set ptpx_additional_search_path   inputs/adk
 set ptpx_target_libraries         inputs/adk/stdcells.db
-set ptpx_extra_link_libraries     [glob -nocomplain inputs/*.db]
+set ptpx_extra_link_libraries     [join "
+                                    [glob -nocomplain inputs/*.db]
+                                    [glob -nocomplain inputs/adk/*.db]
+                                "]
 
 #-------------------------------------------------------------------------
 # Interface to the build system


### PR DESCRIPTION
Makes genlibdb step use all db files in adk as link libs.