### PR TITLE
Look in adk for -bc libs

### DIFF
--- a/steps/cadence-innovus-flowsetup/setup.tcl
+++ b/steps/cadence-innovus-flowsetup/setup.tcl
@@ -92,7 +92,7 @@ set vars(libs_typical,timing) [join "
 if {[file exists $vars(adk_dir)/stdcells-bc.lib]} {
   set vars(libs_bc,timing)    [join "
                                 $vars(adk_dir)/stdcells-bc.lib
-                                [glob -nocomplain $vars(adk_dir)/iocells-bc.lib]
+                                [glob -nocomplain $vars(adk_dir)/*-bc*.lib]
                                 [glob -nocomplain inputs/*ff*.lib]
                                 [glob -nocomplain inputs/*FF*.lib]
                               "]


### PR DESCRIPTION
This PR affects the `cadence-innovus-flowsetup` step. This just adds a glob for libs tagged with "-bc" in the input adk. These changes help support using a fast/bc lib during the innovus flow.