### PR TITLE
removed suffixes from the gdsmerge in fill

### DIFF
--- a/steps/mentor-calibre-fill/configure.yml
+++ b/steps/mentor-calibre-fill/configure.yml
@@ -28,8 +28,8 @@ commands:
   - calibre -gui -drc -batch -runset fill.runset
   # Merge the design GDS with the dummy fill GDS
   - calibredrv -a layout filemerge \
-               -infile [list -name inputs/design.gds -suffix _design] \
-               -infile [list -name {fill_gds} -suffix _fill] \
+               -infile [list -name inputs/design.gds] \
+               -infile [list -name {fill_gds}] \
                -createtop {design_name}_filled \
                -out design_filled.gds
   - mkdir -p outputs && cd outputs


### PR DESCRIPTION
The suffixes cause issues in LVS since the top cell as well as all subcells have the suffix attached.