### PR TITLE
use echo -pipe to fix calibredrv bug

### DIFF
--- a/steps/mentor-calibre-gdsmerge-child/configure.yml
+++ b/steps/mentor-calibre-gdsmerge-child/configure.yml
@@ -32,7 +32,9 @@ commands:
   # For some reason, Calibre requires this directory to exist
   - mkdir -p $HOME/.calibrewb_workspace/tmp
   # Run the merge
-  - calibredrv merge.tcl
+  # Need 'echo |' to stop calibredrv from hanging if the step is backgrounded,
+  # which is a known calibredrv bug noted in the manual (see calibr_drv_ref.pdf)
+  - echo | calibredrv merge.tcl
   # Get the outputs
   - mkdir -p outputs && cd outputs
   - ln -sf ../design_merged.gds

--- a/steps/mentor-calibre-gdsmerge/README.md
+++ b/steps/mentor-calibre-gdsmerge/README.md
@@ -44,3 +44,11 @@ Here is the exact version of calibre:
     % which calibredrv
     /cad/mentor/2018.8/aoi_cal_2018.2_33.24/bin/calibredrv
 
+**Backgrounding problem**
+
+If you put calibredrv in the background it will hang. This is a known
+bug documented in the manual, see `calibr_drv_ref.pdf` where it says
+"Do not start the tool as a background process or the Tcl shell locks up."
+
+To ameliorate the problem, gdsmerge does `"echo | calibredrv ..."`
+instead of `"calibredrv ..."` , this seems to solve the problem.

--- a/steps/mentor-calibre-gdsmerge/configure.yml
+++ b/steps/mentor-calibre-gdsmerge/configure.yml
@@ -29,7 +29,9 @@ commands:
   # Done manually because -indir inputs/adk did not work on Calibre 17
   - ins=""; for f in inputs/adk/*.gds*; do ins="$ins -in $f"; done
   # Use calibredrv to merge gds files
-  - calibredrv -a layout filemerge \
+  # Need 'echo |' to stop calibredrv from hanging if the step is backgrounded,
+  # which is a known calibredrv bug noted in the manual (see calibr_drv_ref.pdf)
+  - echo | calibredrv -a layout filemerge \
                -indir inputs \
                $ins
                -topcell {design_name} \


### PR DESCRIPTION
You will see that I changed steps `gdsmerge` and `gdsmerge-child` and added a note to the gdsmerge README. 

There are other steps that use calibredrv, but they seem to use it more interactively and/or as debug steps, so I did **not** see a need to change those, since it wouldn't really make sense for someone to background them; these steps include
```
mentor-calibre-lvs
mentor-calibre-drc
mentor-calibre-chipart
```
