### PR TITLE
don't search for conftest in assertion pytest

### DIFF
--- a/mflowgen/assertions/assertion_helpers.py
+++ b/mflowgen/assertions/assertion_helpers.py
@@ -86,7 +86,7 @@ def main():
     #
 
     pytest_args = [ '-q', '-rA', '--disable-warnings',
-                    '--tb=short', '--color=yes', f ]
+                    '--tb=short', '--color=yes', '--noconftest', f ]
     print( 'pytest ' + ' '.join( pytest_args ) )
     status = pytest.main( pytest_args )
     exit_status.append( status )


### PR DESCRIPTION
This causes problems when build directories are inside the garnet directory, since pytest finds the garnet confest.py.