### PR TITLE
fail on error: instead of error in synth node

### DIFF
--- a/steps/synopsys-dc-synthesis/configure.yml
+++ b/steps/synopsys-dc-synthesis/configure.yml
@@ -90,7 +90,7 @@ postconditions:
 
   # Basic error checking
 
-  - assert 'error' not in File( 'logs/dc.log' )
+  - assert 'error:' not in File( 'logs/dc.log' )
   - assert 'Unresolved references' not in File( 'logs/dc.log' )
   - assert 'Unable to resolve' not in File( 'logs/dc.log' )
   - assert 'Presto compilation terminated' not in File( 'logs/dc.log' )


### PR DESCRIPTION
Slightly modifies the error assertion in the synthesis node to fire on "error:" instead of "error". This is to prevent false positives on things in the rtl with the name "error" in them, which exist in the Garnet soc rtl.