### PR TITLE
Fixlibs

### DIFF
--- a/steps/cadence-genus-synthesis/scripts/main.tcl
+++ b/steps/cadence-genus-synthesis/scripts/main.tcl
@@ -29,10 +29,6 @@ if { $gate_clock == True } {
 # existing step 'cadence-innovus-flowsetup/setup.tcl'
 #
 # Also, added "lsort" to "glob" for better determinacy.
-# 
-# FIXME This could maybe could/should be wrapped up as a separate common
-# script somewhere? For use by both genus and flowsetup etc?
-# Better: Could be an executable bash script in e.g. "adks/bin"...?
 
 global vars
 set vars(adk_dir) inputs/adk

--- a/steps/cadence-genus-synthesis/scripts/main.tcl
+++ b/steps/cadence-genus-synthesis/scripts/main.tcl
@@ -42,6 +42,10 @@ if { $gate_clock == True } {
 #
 # Also, added "lsort" to "glob" for better determinacy.
 # 
+# Note, genus at the moment only uses typical libraries;
+# I'm leaving the best/worst lists for consistency with flowsetup step,
+# plus maybe someday someone would want to design to one of these cases...?
+# 
 # FIXME This could maybe could/should be wrapped up as a separate common
 # script somewhere? For use by both genus and flowsetup etc?
 # Better: Could be an executable bash script in e.g. "adks/bin"...?

--- a/steps/cadence-genus-synthesis/scripts/main.tcl
+++ b/steps/cadence-genus-synthesis/scripts/main.tcl
@@ -35,6 +35,7 @@ set vars(adk_dir) inputs/adk
 
 #-------------------------------------------------------------------------
 # Typical-case libraries
+
 set vars(libs_typical,timing) \
     [join "
         $vars(adk_dir)/stdcells.lib
@@ -93,6 +94,7 @@ if {[file exists $vars(adk_dir)/stdcells-wc.lib]} {
 
 #-------------------------------------------------------------------------
 # LEF files
+
 set vars(lef_files) \
 [join "
     $vars(adk_dir)/rtk-tech.lef

--- a/steps/cadence-genus-synthesis/scripts/main.tcl
+++ b/steps/cadence-genus-synthesis/scripts/main.tcl
@@ -17,20 +17,120 @@ if { $gate_clock == True } {
   set_attr lp_insert_clock_gating true
 }
  
-set_attr library    [join "
-                      [glob -nocomplain inputs/adk/*.lib]
-                      [glob -nocomplain inputs/*.lib]
-                    "]
+# ------------------------------------------------------------------------
+# (begin compiling library and lef lists)
+# ------------------------------------------------------------------------
 
-set_attr lef_library [join "
-                       inputs/adk/rtk-tech.lef
-                       [glob -nocomplain inputs/adk/*.lef]
-                       [glob -nocomplain inputs/*.lef]
-                     "]
+# OLD/BAD
+# set_attr library    [join "
+#                       [glob -nocomplain inputs/adk/*.lib]
+#                       [glob -nocomplain inputs/*.lib]
+#                     "]
+# 
+# set_attr lef_library [join "
+#                        inputs/adk/rtk-tech.lef
+#                        [glob -nocomplain inputs/adk/*.lef]
+#                        [glob -nocomplain inputs/*.lef]
+#                      "]
+
+########################################################################
+# Library sets
+# 
+# Steveri update Aug 2020: fixed library load ordering.
+# For consistency, using code similar to what I found in
+# existing step 'cadence-innovus-flowsetup/setup.tcl'
+#
+# Also, added "lsort" to "glob" for better determinacy.
+# 
+# FIXME This could maybe could/should be wrapped up as a separate common
+# script somewhere? For use by both genus and flowsetup etc?
+# Better: Could be an executable bash script in e.g. "adks/bin"...?
+
+global vars
+set vars(adk_dir) inputs/adk
+
+########################################################################
+# Typical-case libraries
+set vars(libs_typical,timing) \
+    [join "
+        $vars(adk_dir)/stdcells.lib
+        [lsort [glob -nocomplain $vars(adk_dir)/stdcells-lvt.lib]]
+        [lsort [glob -nocomplain $vars(adk_dir)/stdcells-ulvt.lib]]
+        [lsort [glob -nocomplain $vars(adk_dir)/stdcells-pm.lib]]
+        [lsort [glob -nocomplain $vars(adk_dir)/iocells.lib]]
+        [lsort [glob -nocomplain inputs/*tt*.lib]]
+        [lsort [glob -nocomplain inputs/*TT*.lib]]
+        "]
+puts "INFO: Found typical-typical libraries $vars(libs_typical,timing)"
+foreach L $vars(libs_typical,timing) { echo "L_TT    $L" }
+
+########################################################################
+# Best-case libraries
+# - Process: ff
+# - Voltage: highest
+# - Temperature: highest (temperature inversion at 28nm and below)
+# FIXME note this code repeats all the bc libraries in the list at
+# least twice, because of the extra '*-bc-*' pattern...
+
+if {[file exists $vars(adk_dir)/stdcells-bc.lib]} {
+    set vars(libs_bc,timing) \
+        [join "
+            $vars(adk_dir)/stdcells-bc.lib
+            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-lvt-bc.lib]]
+            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-ulvt-bc.lib]]
+            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-pm-bc.lib]]
+            [lsort [glob -nocomplain $vars(adk_dir)/iocells-bc.lib]]
+            [lsort [glob -nocomplain $vars(adk_dir)/*-bc*.lib]]
+            [lsort [glob -nocomplain inputs/*ff*.lib]]
+            [lsort [glob -nocomplain inputs/*FF*.lib]]
+        "]
+  puts "INFO: Found fast-fast libraries $vars(libs_bc,timing)"
+  foreach L $vars(libs_bc,timing) { echo "L_FF    $L" }
+}
+
+########################################################################
+# Worst-case libraries
+# - Process: ss
+# - Voltage: lowest
+# - Temperature: lowest (temperature inversion at 28nm and below)
+# FIXME is there a reason this only looks for iocells???
+
+if {[file exists $vars(adk_dir)/stdcells-wc.lib]} {
+    set vars(libs_wc,timing) \
+        [join "
+            $vars(adk_dir)/stdcells-wc.lib
+            [lsort [glob -nocomplain $vars(adk_dir)/iocells-wc.lib]]
+            [lsort [glob -nocomplain inputs/*ss*.lib]]
+            [lsort [glob -nocomplain inputs/*SS*.lib]]
+      "]
+  puts "INFO: Found slow-slow libraries $vars(libs_wc,timing)"
+  foreach L $vars(libs_wc,timing) { echo "L_SS    $L" }
+}
+
+########################################################################
+# LEF files
+set vars(lef_files) \
+[join "
+    $vars(adk_dir)/rtk-tech.lef
+    $vars(adk_dir)/stdcells.lef
+    [lsort [glob -nocomplain $vars(adk_dir)/stdcells-pm.lef]]
+    [lsort [glob -nocomplain $vars(adk_dir)/*.lef]]
+    [lsort [glob -nocomplain inputs/*.lef]]
+"]
+
+puts "INFO: Found LEF files $vars(lef_files)"
+foreach L $vars(lef_files) { echo "LEF    $L" }
+
+# ------------------------------------------------------------------------
+# (done compiling library and lef lists)
+# ------------------------------------------------------------------------
+
+set_attr library     $vars(libs_typical,timing)
+set_attr lef_library $vars(lef_files)
 
 set_attr qrc_tech_file [list inputs/adk/pdk-typical-qrcTechFile]
 
-read_hdl -sv [glob -directory inputs -type f *.v *.sv]
+read_hdl -sv [lsort [glob -directory inputs -type f *.v *.sv]]
 elaborate $design_name
 
 source "inputs/adk/adk.tcl"

--- a/steps/cadence-genus-synthesis/scripts/main.tcl
+++ b/steps/cadence-genus-synthesis/scripts/main.tcl
@@ -21,18 +21,6 @@ if { $gate_clock == True } {
 # (begin compiling library and lef lists)
 # ------------------------------------------------------------------------
 
-# OLD/BAD
-# set_attr library    [join "
-#                       [glob -nocomplain inputs/adk/*.lib]
-#                       [glob -nocomplain inputs/*.lib]
-#                     "]
-# 
-# set_attr lef_library [join "
-#                        inputs/adk/rtk-tech.lef
-#                        [glob -nocomplain inputs/adk/*.lef]
-#                        [glob -nocomplain inputs/*.lef]
-#                      "]
-
 ########################################################################
 # Library sets
 # 

--- a/steps/cadence-genus-synthesis/scripts/main.tcl
+++ b/steps/cadence-genus-synthesis/scripts/main.tcl
@@ -17,11 +17,11 @@ if { $gate_clock == True } {
   set_attr lp_insert_clock_gating true
 }
  
-# ------------------------------------------------------------------------
+#-------------------------------------------------------------------------
 # (begin compiling library and lef lists)
-# ------------------------------------------------------------------------
+#-------------------------------------------------------------------------
 
-########################################################################
+#-------------------------------------------------------------------------
 # Library sets
 # 
 # Steveri update Aug 2020: fixed library load ordering.
@@ -33,7 +33,7 @@ if { $gate_clock == True } {
 global vars
 set vars(adk_dir) inputs/adk
 
-########################################################################
+#-------------------------------------------------------------------------
 # Typical-case libraries
 set vars(libs_typical,timing) \
     [join "
@@ -48,7 +48,7 @@ set vars(libs_typical,timing) \
 puts "INFO: Found typical-typical libraries $vars(libs_typical,timing)"
 foreach L $vars(libs_typical,timing) { echo "L_TT    $L" }
 
-########################################################################
+#-------------------------------------------------------------------------
 # Best-case libraries
 # - Process: ff
 # - Voltage: highest
@@ -72,7 +72,7 @@ if {[file exists $vars(adk_dir)/stdcells-bc.lib]} {
   foreach L $vars(libs_bc,timing) { echo "L_FF    $L" }
 }
 
-########################################################################
+#-------------------------------------------------------------------------
 # Worst-case libraries
 # - Process: ss
 # - Voltage: lowest
@@ -91,7 +91,7 @@ if {[file exists $vars(adk_dir)/stdcells-wc.lib]} {
   foreach L $vars(libs_wc,timing) { echo "L_SS    $L" }
 }
 
-########################################################################
+#-------------------------------------------------------------------------
 # LEF files
 set vars(lef_files) \
 [join "
@@ -105,9 +105,9 @@ set vars(lef_files) \
 puts "INFO: Found LEF files $vars(lef_files)"
 foreach L $vars(lef_files) { echo "LEF    $L" }
 
-# ------------------------------------------------------------------------
+#-------------------------------------------------------------------------
 # (done compiling library and lef lists)
-# ------------------------------------------------------------------------
+#-------------------------------------------------------------------------
 
 set_attr library     $vars(libs_typical,timing)
 set_attr lef_library $vars(lef_files)

--- a/steps/cadence-genus-synthesis/scripts/main.tcl
+++ b/steps/cadence-genus-synthesis/scripts/main.tcl
@@ -30,10 +30,6 @@ if { $gate_clock == True } {
 #
 # Also, added "lsort" to "glob" for better determinacy.
 # 
-# Note, genus at the moment only uses typical libraries;
-# I'm leaving the best/worst lists for consistency with flowsetup step,
-# plus maybe someday someone would want to design to one of these cases...?
-# 
 # FIXME This could maybe could/should be wrapped up as a separate common
 # script somewhere? For use by both genus and flowsetup etc?
 # Better: Could be an executable bash script in e.g. "adks/bin"...?


### PR DESCRIPTION
Fixed library load ordering for Genus step. Previously the load was random and potentially included a mix of libraries including both tt and ff etc, now it loads *only* typical libraries. The step also compiles, but does not use, lists of best- and worst-case libraries.

For consistency, I'm using code similar to what I found in existing step 'cadence-innovus-flowsetup/setup.tcl'

Also, added "lsort" to "glob" for better determinacy.

This fix seems to be working through multiple tests, e.g. memtile works at
250MHz (3 hours to build) https://buildkite.com/tapeout-aha/mflowgen/builds/2225

500 MHz (4 hrs) https://buildkite.com/tapeout-aha/mflowgen/builds/2226

750 MHz  (5.5 hrs) https://buildkite.com/tapeout-aha/mflowgen/builds/2227


and 800 MHz (12 hrs) https://buildkite.com/tapeout-aha/mflowgen/builds/2228

