### PR TITLE
Utilize the flatten_effort parameter from design graphs

### DIFF
--- a/steps/cadence-genus-synthesis/configure.yml
+++ b/steps/cadence-genus-synthesis/configure.yml
@@ -45,6 +45,7 @@ parameters:
   # This is useful for hierarchical LVS when multiple blocks use modules
   # with the same name but different definitions.
   uniquify_with_design_name: True
+  flatten_effort: 0
   order:
     - main.tcl
     - write_results.tcl

--- a/steps/cadence-genus-synthesis/scripts/main.tcl
+++ b/steps/cadence-genus-synthesis/scripts/main.tcl
@@ -10,6 +10,17 @@ set design_name                $::env(design_name)
 set clock_period               $::env(clock_period)
 set gate_clock                 $::env(gate_clock)
 set uniquify_with_design_name  $::env(uniquify_with_design_name)
+set flatten_effort             $::env(flatten_effort)
+
+set auto_ungroup_val "both"
+# Here we do a weird mapping from our DC flatten_effort to genus flatten_effort
+# flatten_effort=0 goes to no flattening
+# flatten_effort!=0 goes to flattening to optimize for area + timing (genus default)
+# For more info: help auto_ungroup
+if { $flatten_effort == 0 } {
+  puts "Disabling automatic flattening."
+  set auto_ungroup_val "none"
+}
 
 set_db common_ui false
 
@@ -46,6 +57,10 @@ if { $uniquify_with_design_name == True } {
 set_attribute avoid true [get_lib_cells {*/E* */G* *D16* *D20* *D24* *D28* *D32* SDF* *DFM*}]
 # don't use Scan enable D flip flops
 set_attribute avoid true [get_lib_cells {*SEDF*}]
+# Obey flattening effort of mflowgen graph
+puts "printing autoungroup" 
+puts $auto_ungroup_val
+set_attribute auto_ungroup $auto_ungroup_val
 
 syn_gen
 set_attr syn_map_effort high

--- a/steps/cadence-genus-synthesis/scripts/main.tcl
+++ b/steps/cadence-genus-synthesis/scripts/main.tcl
@@ -58,8 +58,6 @@ set_attribute avoid true [get_lib_cells {*/E* */G* *D16* *D20* *D24* *D28* *D32*
 # don't use Scan enable D flip flops
 set_attribute avoid true [get_lib_cells {*SEDF*}]
 # Obey flattening effort of mflowgen graph
-puts "printing autoungroup" 
-puts $auto_ungroup_val
 set_attribute auto_ungroup $auto_ungroup_val
 
 syn_gen


### PR DESCRIPTION
This PR adds `flatten_effort` to the genus main synthesis script. This will read our DC-esque flatten_effort parameter from our design graphs and map it to the genus equivalent. We take flatten_effort = 0 to a "none" argument in genus, which prevents autoungrouping. The flatten effort in genus (attribute auto_ungroup) takes on the values of {none, area, timing, both}, so Alex and I decided to map a flatten_effort != 0 to mean "both" in genus. "both" is the default setting in genus.