### PR TITLE
Set flatten_complex_port attribute in genus script

### DIFF
--- a/steps/cadence-genus-synthesis/scripts/main.tcl
+++ b/steps/cadence-genus-synthesis/scripts/main.tcl
@@ -116,6 +116,8 @@ set_attr lef_library $vars(lef_files)
 
 set_attr qrc_tech_file [list inputs/adk/pdk-typical-qrcTechFile]
 
+set_attr hdl_flatten_complex_port true
+
 read_hdl -sv [lsort [glob -directory inputs -type f *.v *.sv]]
 elaborate $design_name
 


### PR DESCRIPTION
Prevents output verilog from genus nodes from having 2 complex ports. Needed this change for the glb_top flow, because the 2d array ports broke the pin placement scripts.