### PR TITLE
Dump sdf and spef

### DIFF
--- a/steps/cadence-genus-synthesis/configure.yml
+++ b/steps/cadence-genus-synthesis/configure.yml
@@ -19,6 +19,8 @@ inputs:
 outputs:
   - design.v
   - design.sdc
+  - design.sdf
+  - design.spef
   - design.namemap
 
 #-------------------------------------------------------------------------
@@ -30,6 +32,8 @@ commands:
   - mkdir -p outputs && cd outputs
   - ln -sf ../results_syn/syn_out.v design.v
   - ln -sf ../results_syn/syn_out._default_constraint_mode_.sdc design.sdc
+  - ln -sf ../results_syn/syn_out.sdf design.sdf
+  - ln -sf ../results_syn/syn_out.spef design.spef
   - ln -sf ../name_map.rpt design.namemap
 
 #-------------------------------------------------------------------------
@@ -71,6 +75,8 @@ postconditions:
 
   - assert File( 'outputs/design.v' )        # must exist
   - assert File( 'outputs/design.sdc' )      # must exist
+  - assert File( 'outputs/design.sdf' )      # must exist
+  - assert File( 'outputs/design.spef' )      # must exist
 
   # Basic error checking
 

--- a/steps/cadence-genus-synthesis/scripts/write_results.tcl
+++ b/steps/cadence-genus-synthesis/scripts/write_results.tcl
@@ -8,6 +8,8 @@
 
 write_snapshot -directory results_syn -tag final
 write_design -innovus -basename results_syn/syn_out
+write_sdf > results_syn/syn_out.sdf
+write_spef > results_syn/syn_out.spef
 
 write_name_mapping
 


### PR DESCRIPTION
Dump `sdf` file and `spef` file in `cadence-genus-synthesis` step.
May need those files in gate level simulation with netlist.