### PR TITLE
change stream-out script to merge in all input gds files

### DIFF
--- a/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/stream-out.tcl
+++ b/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/stream-out.tcl
@@ -6,13 +6,17 @@
 # Author : Christopher Torng
 # Date   : March 26, 2018
 
+streamOut $vars(results_dir)/$vars(design).gds.gz \
+    -units 1000 \
+    -mapFile $vars(gds_layer_map)
+
 set merge_files \
     [concat \
         [glob -nocomplain inputs/adk/*.gds*] \
         [glob -nocomplain inputs/*.gds*] \
     ]
 
-streamOut $vars(results_dir)/$vars(design).gds.gz \
+streamOut $vars(results_dir)/$vars(design)_innovus_merged.gds \
     -units 1000 \
     -mapFile $vars(gds_layer_map) \
     -merge $merge_files

--- a/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/stream-out.tcl
+++ b/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/stream-out.tcl
@@ -16,7 +16,7 @@ set merge_files \
         [glob -nocomplain inputs/*.gds*] \
     ]
 
-streamOut $vars(results_dir)/$vars(design)_innovus_merged.gds \
+streamOut $vars(results_dir)/$vars(design)-merged.gds \
     -units 1000 \
     -mapFile $vars(gds_layer_map) \
     -merge $merge_files

--- a/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/stream-out.tcl
+++ b/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/stream-out.tcl
@@ -6,5 +6,15 @@
 # Author : Christopher Torng
 # Date   : March 26, 2018
 
-streamOut $vars(results_dir)/$vars(design).gds.gz -units 1000 -mapFile $vars(gds_layer_map)
+set merge_files \
+    [concat \
+        [glob -nocomplain inputs/adk/*.gds*] \
+        [glob -nocomplain inputs/*.gds*] \
+    ]
+
+streamOut $vars(results_dir)/$vars(design).gds.gz \
+    -units 1000 \
+    -mapFile $vars(gds_layer_map) \
+    -merge $merge_files
+               
 

--- a/steps/cadence-innovus-signoff/configure.yml
+++ b/steps/cadence-innovus-signoff/configure.yml
@@ -19,7 +19,7 @@ inputs:
 outputs:
   - design.checkpoint
   - design.gds.gz
-  - design_innovus_merged.gds
+  - design-merged.gds
   - design.lvs.v
   - design.vcs.v
   - design.vcs.pg.v
@@ -42,7 +42,7 @@ commands:
   - ln -sf ../checkpoints/design.checkpoint
   - ln -sf ../typical.spef.gz             design.spef.gz
   - ln -sf ../results/*.gds.gz            design.gds.gz
-  - ln -sf ../results/*innovus_merged.gds design_innovus_merged.gds
+  - ln -sf ../results/*-merged.gds        design-merged.gds
   - ln -sf ../results/*.lvs.v             design.lvs.v
   - ln -sf ../results/*.vcs.v             design.vcs.v
   - ln -sf ../results/*.vcs.pg.v          design.vcs.pg.v

--- a/steps/cadence-innovus-signoff/configure.yml
+++ b/steps/cadence-innovus-signoff/configure.yml
@@ -19,6 +19,7 @@ inputs:
 outputs:
   - design.checkpoint
   - design.gds.gz
+  - design_innovus_merged.gds
   - design.lvs.v
   - design.vcs.v
   - design.vcs.pg.v
@@ -39,15 +40,16 @@ commands:
   # Outputs
   - cd outputs
   - ln -sf ../checkpoints/design.checkpoint
-  - ln -sf ../typical.spef.gz      design.spef.gz
-  - ln -sf ../results/*.gds.gz     design.gds.gz
-  - ln -sf ../results/*.lvs.v      design.lvs.v
-  - ln -sf ../results/*.vcs.v      design.vcs.v
-  - ln -sf ../results/*.vcs.pg.v   design.vcs.pg.v
-  - ln -sf ../results/*.lef        design.lef
-  - ln -sf ../results/*.pt.sdc     design.pt.sdc
-  - ln -sf ../results/*.sdf        design.sdf
-  - ln -sf ../results/*.virtuoso.v design.virtuoso.v
+  - ln -sf ../typical.spef.gz             design.spef.gz
+  - ln -sf ../results/*.gds.gz            design.gds.gz
+  - ln -sf ../results/*innovus_merged.gds design_innovus_merged.gds
+  - ln -sf ../results/*.lvs.v             design.lvs.v
+  - ln -sf ../results/*.vcs.v             design.vcs.v
+  - ln -sf ../results/*.vcs.pg.v          design.vcs.pg.v
+  - ln -sf ../results/*.lef               design.lef
+  - ln -sf ../results/*.pt.sdc            design.pt.sdc
+  - ln -sf ../results/*.sdf               design.sdf
+  - ln -sf ../results/*.virtuoso.v        design.virtuoso.v
 
 #-------------------------------------------------------------------------
 # Parameters


### PR DESCRIPTION
Makes the stream out script in the foundation flow automatically merge in all adk gds files, as well as any other input gds files.