### PR TITLE
Pegasus DRC Node

### DIFF
--- a/steps/cadence-pegasus-drc/configure.yml
+++ b/steps/cadence-pegasus-drc/configure.yml
@@ -1,0 +1,60 @@
+#=========================================================================
+# Cadence Pegasus DRC
+#=========================================================================
+# Author : Maxwell Strange
+# Date   : October 14, 2020
+#
+
+name: cadence-pegasus-drc
+
+#-------------------------------------------------------------------------
+# Inputs and Outputs
+#-------------------------------------------------------------------------
+
+inputs:
+  - design_merged.gds
+  - adk
+
+outputs:
+  - drc.results
+
+#-------------------------------------------------------------------------
+# Parameters
+#-------------------------------------------------------------------------
+
+parameters:
+  design_name: undefined
+  # Use the rule deck "inputs/adk/${drc_rule_deck}"
+  drc_rule_deck: pegasus-drc-block.rule
+
+#-------------------------------------------------------------------------
+# Commands
+#-------------------------------------------------------------------------
+
+commands:
+  - mkdir -p logs
+  - pegasus -drc -gds ./inputs/adk/${drc_rule_deck} -top_cell ${design_name} -log_dir ./logs/ -interactive
+  - mkdir -p outputs && cd outputs
+  - ln -sf ../DRC.rep ./drc.summary
+  # - ln -sf ../drc.summary
+
+#-------------------------------------------------------------------------
+# Debug
+#-------------------------------------------------------------------------
+
+# debug:
+#   - calibredrv -m inputs/design_merged.gds \
+#                -l inputs/adk/calibre.layerprops \
+#                -rve -drc drc.results
+
+#-------------------------------------------------------------------------
+# Assertions
+#-------------------------------------------------------------------------
+
+preconditions:
+
+  - assert Tool( 'pegasus' )
+  - assert File( 'inputs/adk' )
+  - assert File( 'inputs/design_merged.gds' )
+
+


### PR DESCRIPTION
This PR adds a pegasus drc node with same inputs as the mentor calibre drc node.

Currently I need to run the node with the Interactive Engine, otherwise the tool won't work. 

Need to add debug mode for the node.