### PR TITLE
ensure that hcell var is defined in all cases

### DIFF
--- a/steps/cadence-pegasus-lvs/run.sh
+++ b/steps/cadence-pegasus-lvs/run.sh
@@ -1,4 +1,5 @@
-if [ ! -z "$lvs_hcells_file" ]; then hcell="-hcell $lvs_hcells_file"; fi
+if [ ! -z "$lvs_hcells_file" ]; then hcell="-hcell $lvs_hcells_file";
+else hcell=""; fi
 black_box=""
 if [ -e inputs/rules.svrf ]; then
   while read line; do

--- a/steps/cadence-pegasus-lvs/run.sh
+++ b/steps/cadence-pegasus-lvs/run.sh
@@ -1,5 +1,7 @@
-if [ ! -z "$lvs_hcells_file" ]; then hcell="-hcell $lvs_hcells_file";
-else hcell=""; fi
+hcell=""
+if [ ! -z "$lvs_hcells_file" ]; then
+  hcell="-hcell $lvs_hcells_file";
+fi
 black_box=""
 if [ -e inputs/rules.svrf ]; then
   while read line; do


### PR DESCRIPTION
Bug fix for Pegasus LVS. If the hcell file wasn't provided, then the hcell variable was used but not defined.