### PR TITLE
No backslashes in genus elab

### DIFF
--- a/steps/cadence-genus-synthesis/scripts/compile.tcl
+++ b/steps/cadence-genus-synthesis/scripts/compile.tcl
@@ -4,7 +4,7 @@
 # Author : Alex Carsello
 # Date   : September 28, 2020
 
-set_attr uniquify_naming_style "%s_%d"
+set_attribute uniquify_naming_style %s_%d
 uniquify $design_name
 
 # Obey flattening effort of mflowgen graph

--- a/steps/cadence-genus-synthesis/scripts/read-design.tcl
+++ b/steps/cadence-genus-synthesis/scripts/read-design.tcl
@@ -5,5 +5,10 @@
 # Date   : September 28, 2020
 
 read_hdl -sv [lsort [glob -directory inputs -type f *.v *.sv]]
+# Prevent backslashes from being prepended to signal names...
+# this causes SAIF files to be invalid...needs to be before elab.
+set_attribute hdl_array_naming_style %s_%d
+set_attribute hdl_bus_wire_naming_style %s_%d
+set_attribute bit_blasted_port_style %s_%d /
 elaborate $design_name
 


### PR DESCRIPTION
This PR adds necessary commands to set some attributes for gate level code gen. This will prevent any backslashes from being prepended to signal names, which is necessary for the downstream power flows.